### PR TITLE
Fix dnssrv crash when network name contains hyphens

### DIFF
--- a/scripts/dnssrv.sh
+++ b/scripts/dnssrv.sh
@@ -167,7 +167,7 @@ set_container_records(){
 	safename=$(get_safename "$name")
 	hostname=$(get_hostname "$cid")
 	domainname=$(get_domainname "$cid")
-	aliases=$(docker inspect -f '{{range .NetworkSettings.Networks.'$cnetwork'.Aliases}}{{.}} {{end}}' "$cid")
+	aliases=$(docker inspect -f "{{range (index .NetworkSettings.Networks \"${cnetwork}\").Aliases}}{{.}} {{end}}" "$cid")
 
 	[ -n "$domain" ] && add_record "${safename}.${domain}" "$ip" "$safename" || :
 	[ -n "$hostname" -a -n "$domain" -a "$domain" != "$domainname" ] && add_record "${hostname}.${domain}" "$ip" "$safename" || :


### PR DESCRIPTION
## Summary

Fixes #5 — `dnssrv` crashes with a Go template parsing error (`bad character U+002D '-'`) when the Docker network name contains hyphens (e.g., `hermacoregit_herma-core`).

## Root Cause

In `set_container_records()`, the network aliases lookup on line 170 used Go template dot-field traversal:

```go
{{range .NetworkSettings.Networks.NETWORKNAME.Aliases}}
```

Go templates treat the interpolated network name as an identifier, and hyphens are not valid in Go identifiers.

## Fix

Replace with the `index` function, which accepts the network name as a quoted string — the same pattern already used on the adjacent IP lookup (line 165):

```go
{{range (index .NetworkSettings.Networks "NETWORKNAME").Aliases}}
```

This is a one-line change with no behavioral difference for hyphen-free network names.