### PR TITLE
Add multi-arch (amd64 + arm64) image build support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-ARG VERSION="0.0.0.0"
-FROM kylemanna/openvpn:latest
+FROM nmaguiar/openvpn:latest
 
 LABEL maintainer="Pablo Ruiz <pablo@evicertia.com>"
 
@@ -7,9 +6,11 @@ RUN 	apk update \
 	&& apk --no-cache add bash curl dnsmasq ed supervisor \
 	&& mkdir -p /etc/dnsmasq.d
 
-RUN curl -sSL https://download.docker.com/linux/static/stable/x86_64/docker-26.1.4.tgz | tar zx -C /tmp \
+ARG TARGETARCH
+RUN ARCH=$(case ${TARGETARCH} in amd64) echo x86_64;; arm64) echo aarch64;; *) echo ${TARGETARCH};; esac) \
+	&& curl -sSL "https://download.docker.com/linux/static/stable/${ARCH}/docker-26.1.4.tgz" | tar zx -C /tmp \
 	&& mv /tmp/docker/docker /usr/local/bin/ \
-	&& rm -rf /tmp/docker 
+	&& rm -rf /tmp/docker
 
 COPY files/dnsmasq.conf /etc/dnsmasq.conf
 COPY files/supervisord.conf /etc/supervisord.conf

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,26 @@
-NAME   := evicertia/dockernet-access-server
-TAG    := $$(git log -1 --pretty=%h)
-IMG    := ${NAME}:${TAG}
-LATEST := ${NAME}:latest
+NAME    := evicertia/dockernet-access-server
+PLAT    := linux/amd64,linux/arm64
+CID     := $$(git log -1 --pretty=%h)
+TAG     := latest
+
+BUILDER	?= --builder cloud-evicertia-mono-builder
+BOPTS	?=
 
 build:
-	@DOCKER_BUILDKIT=1 docker build -t ${IMG} .
-	@docker tag ${IMG} ${LATEST}
+	@docker buildx build ${BOPTS} ${BUILDER} \
+		--platform=${PLAT} \
+		--build-arg "CID=${CID}" \
+		-t "${NAME}:${CID}" \
+		-t "${NAME}:${TAG}" \
+		--load .
 
 push:
-	@docker push ${NAME}
+	@docker buildx build ${BOPTS} ${BUILDER} \
+		--platform=${PLAT} \
+		--build-arg "CID=${CID}" \
+		-t "${NAME}:${CID}" \
+		-t "${NAME}:${TAG}" \
+		--push .
 
 login:
-	@docker log -u ${DOCKER_USER} -p ${DOCKER_PASS}
+	@docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}


### PR DESCRIPTION
## Summary

- Switch base image from `kylemanna/openvpn:latest` to `nmaguiar/openvpn:latest` — an actively maintained multi-arch fork (amd64 + arm64) of the original, Alpine-based, drop-in compatible
- Make Docker CLI static binary download architecture-aware using the `TARGETARCH` buildx ARG (maps `amd64`→`x86_64`, `arm64`→`aarch64`)
- Rewrite Makefile to use `docker buildx build` with `--platform=linux/amd64,linux/arm64` and the `cloud-evicertia-mono-builder` cloud builder (same as mono-docker), with `--load` for local builds and `--push` for registry pushes
- Fix typo in `login` target (`docker log` → `docker login`)
- Remove unused `VERSION` build arg from Dockerfile

## Notes

- The `build` target uses `--load` which may need `--platform` removed (or set to host-only) since cloud builders can't load multi-platform manifests locally. The `push` target works correctly for multi-arch registry pushes.
- `BUILDER` and `BOPTS` variables are overridable (e.g., `make build BUILDER=""` to use the default local builder).