### PR TITLE
Add configurable OVPN_SERVER subnet support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ Once connected you should be able to:
 | `NAMING` | `default` | Container naming strategy for DNS |
 | `NETWORK` | `bridge` | Docker network to monitor |
 | `FALLBACK_DNS` | `gateway.docker.internal` | Upstream DNS server |
-| `OVPN_NETWORK` | `172.16.0.0/12` | VPN client address range |
+| `OVPN_SERVER` | `192.168.255.0/24` | VPN server subnet used to assign client IPs |
+| `OVPN_NETWORK` | `172.16.0.0/12` | Route pushed to clients for Docker network reachability |
 | `OVPN_KEEPCONFIG` | (unset) | Skip config regeneration if set |
 | `DEBUG` | (unset) | Enable bash tracing if non-empty |
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
     ports:
       - "1194:1194/udp"
     environment:
+      OVPN_SERVER: ${OVPN_SERVER:-192.168.255.0/24}
       OVPN_NETWORK: 172.16.0.0/12
     volumes:
       - ./scripts/ovpnsrv.sh:/ovpnsrv.sh:ro

--- a/scripts/ovpnsrv.sh
+++ b/scripts/ovpnsrv.sh
@@ -9,6 +9,7 @@ LOCALROUTE=$(ip -4 route |egrep  "src[[:space:]]+$(echo -n $LOCALADDR|sed -e 's/
 
 : ${OVPN_DOMAIN:=test}
 : ${OVPN_NETWORK:=$LOCALROUTE}
+: ${OVPN_SERVER:=192.168.255.0/24}
 : ${OVPN_ENDPOINT:=udp://localhost}
 : ${OVPN_CLIENTCFG:=dockernet.ovpn}
 : ${OVPN_NETNAME:=DOCKERNET}
@@ -42,6 +43,7 @@ if [ "$OVPN_KEEPCONFIG" != "1" -o ! -f "/etc/openvpn/openvpn.conf" ]; then
 	source <(ipcalc -n -m "$OVPN_NETWORK")
 
 	ovpn_command="ovpn_genconfig -d -D -b -N -u \"${OVPN_ENDPOINT}\" \
+		-s \"${OVPN_SERVER}\" \
 		-k \"${OVPN_KEEPALIVE}\" \
 		-e 'persist-remote-ip' \
 		-e 'script-security 2' \


### PR DESCRIPTION
## Summary
- add `OVPN_SERVER` handling in `scripts/ovpnsrv.sh` and pass it to `ovpn_genconfig -s` so OpenVPN client IP allocation subnet is configurable
- expose `OVPN_SERVER` in `docker-compose.yml` with a default (`${OVPN_SERVER:-192.168.255.0/24}`), so it remains optional
- update README environment variable docs to distinguish `OVPN_SERVER` (client allocation subnet) from `OVPN_NETWORK` (route pushed to clients)